### PR TITLE
informative error message if 'median' used in stat.data or panel.data, for #50

### DIFF
--- a/R/mmPlot.r
+++ b/R/mmPlot.r
@@ -245,6 +245,14 @@ mmplot.default <- function(map.data,
                            ...
 ){		
   
+  # stop if 'median' is a column name in stat.data
+  if('median' %in% names(stat.data))
+    stop('"median" cannot be a column name in stat.data')
+  
+  # stop if 'median' is used in panel.data
+  if('median' %in% unlist(panel.data))
+    stop('"median" cannot be used in panel.data')
+  
   # rename function inputs
   dStats <- stat.data
   dMap <- map.data


### PR DESCRIPTION
Error for stat.data
```
data(USstates)
data(edPov)
statePolys <- create_map_table(USstates, IDcolumn="ST")

names(edPov)[names(edPov) %in% 'ed'] <- 'median'

mmplot(stat.data=edPov,map.data=statePolys,
        panel.types=c("labels", "dot","dot", "map"),
        panel.data=list("state","pov","ed", NA),
        ord.by="pov", grouping=5,
        median.row=T,
        map.link=c("StateAb","ID")
        )
###  Error in mmplot.default(stat.data = edPov, map.data = statePolys, panel.types = c("labels",  : 
###   "median" cannot be a column name in stat.data 
```
Error for panel.data
```
data(USstates)
data(edPov)
statePolys <- create_map_table(USstates, IDcolumn="ST")

mmplot(stat.data=edPov,map.data=statePolys,
        panel.types=c("labels", "dot","dot", "map"),
        panel.data=list("state","pov","median", NA),
        ord.by="pov", grouping=5,
        median.row=T,
        map.link=c("StateAb","ID")
        )

###  Error in mmplot.default(stat.data = edPov, map.data = statePolys, panel.types = c("labels",  : 
###   "median" cannot be used in panel.data 
```


